### PR TITLE
Explicitly identify given names and surnames to fix JOSS metadata

### DIFF
--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -7,7 +7,8 @@ authors:
   - name: Sierra V. Brown
     orcid: 0000-0001-6065-5461
     affiliation: 1
-  - name: Michael St. Clair
+  - given-names: Michael
+    surname: St. Clair
     orcid: 0000-0002-7877-3148
     affiliation: 1
   - name: Chase Million


### PR DESCRIPTION
The only remaining issue I've identified for the [publication in JOSS](https://github.com/openjournals/joss-reviews/issues/7256) is that the metadata is separating Michael St. Clair's as having given names "Michael St." and surname "Clair". I suspect from Michael's [ORCID page](https://orcid.org/0000-0002-7877-3148) that their surname is actually "St. Clair". If so, this PR should fix it.

Because this is a bit technical, I've opened this PR with what I think should be the correct separation of the given names and names in the metadata. Once this is merged I'll check again whether the metadata is interpreted correctly.

If Michael's surname is just "Clair", you can just close this.